### PR TITLE
Fixed a typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django==1.9.6
-psycopg2=2.6.1
+psycopg2==2.6.1


### PR DESCRIPTION
Fixed a typo of missing `=` in the requirements.txt
